### PR TITLE
Fixed text selection will cover over link text

### DIFF
--- a/public/styles/hackdash/base.less
+++ b/public/styles/hackdash/base.less
@@ -1,9 +1,12 @@
 
 ::selection {
   background: @color-action; /* WebKit/Blink Browsers */
+  white: @color-white;
+
 }
 ::-moz-selection {
   background: @color-action; /* Gecko Browsers */
+  white: @color-white;
 }
 
 .no-select {


### PR DESCRIPTION
Before:
<img width="573" alt="2017-01-21 7 18 19" src="https://cloud.githubusercontent.com/assets/93509/22174020/651a8fce-e00e-11e6-8b3f-89e199934d0a.png">

After:
<img width="579" alt="2017-01-21 7 18 03" src="https://cloud.githubusercontent.com/assets/93509/22174019/651537e0-e00e-11e6-90eb-292e5863174a.png">
